### PR TITLE
Add config support for transport addresses

### DIFF
--- a/ictransport/config.toml
+++ b/ictransport/config.toml
@@ -1,0 +1,9 @@
+[pi]
+username = "pi"
+address = "raspberrypi.local"
+share_path = "~/ic-transport"
+
+[hpc]
+username = "hpcuser"
+address = "hpc.example.com"
+share_path = "~/ic-transport"


### PR DESCRIPTION
## Summary
- add `config.toml` to store host/usernames and share paths
- load configuration in `ictransport` module
- default `LaptopTransport` and `NodeTransport` parameters now read from config

## Testing
- `python -m py_compile ictransport/ictransport.py`
- `python -m py_compile ictransport/__init__.py ictransport/examples/hpc_template.py ictransport/examples/pi_template.py ictransport/examples/laptop_template.py ictransport/examples/init_test.py ictransport/ictransport.py`


------
https://chatgpt.com/codex/tasks/task_e_686a65ed2eac832c9259f9c299637261